### PR TITLE
Certmgr scope

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -21,7 +21,7 @@ This module will use install cert-manager into a Kubernetes cluster and configur
 | additional\_yaml\_config | yaml config for helm chart to be processed last | `string` | `""` | no |
 | cert\_manager\_version | cert-manager helm chart version | `string` | `"v0.15.0"` | no |
 | create\_kubernetes\_namespace | create kubernetes namespace if not present | `bool` | `true` | no |
-| domains | map of domains to domain ids and resource groups which certificates will be generated for | `map(object({id = string, resource_group = string}))` | `{}` | no |
+| domains | map of domains to domain ids and resource groups which certificates will be generated for | <pre>map(object({<br>                  id             = string # id of dns zone <br>                  resource_group = string # name of resource group containing the dns zone<br>                }))</pre> | `{}` | no |
 | helm\_release\_name | helm release name | `string` | `"cert-manager"` | no |
 | install\_crds | install cert-manager crds | `bool` | `true` | no |
 | issuers | n/a | <pre>map(object({<br>    namespace             = string # kubernetes namespace<br>    cluster_issuer        = bool   # setting 'true' will create a ClusterIssuer, setting 'false' will create a namespace isolated Issuer<br>    email_address         = string # email address used for expiration notification<br>    domain                = string # azuredns hosted domain (must be listed in var.domains)<br>    letsencrypt_endpoint  = string # letsencrypt endpoint (https://letsencrypt.org/docs/acme-protocol-updates).  Allowable inputs are 'staging', 'production' or a full URL<br>  }))</pre> | `{}` | no |

--- a/cert-manager/main.tf
+++ b/cert-manager/main.tf
@@ -1,5 +1,11 @@
-data "azurerm_resource_group" "rg" {
-  name = var.resource_group_name
+data "azurerm_dns_zone" "zone" {
+  for_each = var.domains
+  name                = each.key
+  resource_group_name = each.value["resource_group"]
+}
+
+data "azurerm_subscription" "subscription" {
+  subscription_id = var.subscription_id
 }
 
 resource "azurerm_user_assigned_identity" "cert_manager" {
@@ -13,7 +19,7 @@ resource "azurerm_role_definition" "cert_manager" {
   for_each    = var.domains
   name        = "${var.names.product_group}-${var.names.subscription_type}-certmgr${local.delimiter}${var.name_identifier}-${each.key}"
   description = "Allow cert manager to use TXT entries for verification"
-  scope       = data.azurerm_resource_group.rg.id
+  scope       = data.azurerm_subscription.subscription.id
 
   permissions {
     actions     = ["Microsoft.Network/dnszones/TXT/read",
@@ -22,12 +28,12 @@ resource "azurerm_role_definition" "cert_manager" {
     not_actions = []
   }
 
-  assignable_scopes = [data.azurerm_resource_group.rg.id]
+  assignable_scopes = [data.azurerm_dns_zone.zone[each.key].id]
 }
 
 resource "azurerm_role_assignment" "cert_manager" {
   for_each           = var.domains
-  scope              = each.value
+  scope              = each.value["id"]
   role_definition_id = azurerm_role_definition.cert_manager[each.key].id
   principal_id       = azurerm_user_assigned_identity.cert_manager.principal_id
 }

--- a/cert-manager/main.tf
+++ b/cert-manager/main.tf
@@ -1,7 +1,7 @@
 data "azurerm_dns_zone" "zone" {
   for_each = var.domains
   name                = each.key
-  resource_group_name = each.value["resource_group"]
+  resource_group_name = each.value.resource_group
 }
 
 data "azurerm_subscription" "subscription" {
@@ -33,7 +33,7 @@ resource "azurerm_role_definition" "cert_manager" {
 
 resource "azurerm_role_assignment" "cert_manager" {
   for_each           = var.domains
-  scope              = each.value["id"]
+  scope              = each.value.id
   role_definition_id = azurerm_role_definition.cert_manager[each.key].id
   principal_id       = azurerm_user_assigned_identity.cert_manager.principal_id
 }

--- a/cert-manager/variables.tf
+++ b/cert-manager/variables.tf
@@ -60,8 +60,9 @@ variable "install_crds" {
 }
 
 variable "domains" {
-  description = "map of domains to domain ids which certificates will be generated for"
-  type        = map(string)
+  description = "map of domains to domain ids and resource groups which certificates will be generated for"
+  #type        = map(string)
+  type        = map(object({id = string, resource_group = string}))
 }
 
 variable "additional_yaml_config" {

--- a/cert-manager/variables.tf
+++ b/cert-manager/variables.tf
@@ -61,7 +61,10 @@ variable "install_crds" {
 
 variable "domains" {
   description = "map of domains to domain ids and resource groups which certificates will be generated for"
-  type        = map(object({id = string, resource_group = string}))
+  type        = map(object({
+                  id             = string # id of dns zone 
+                  resource_group = string # name of resource group containing the dns zone
+                }))
   default     = {}
 }
 

--- a/cert-manager/variables.tf
+++ b/cert-manager/variables.tf
@@ -61,8 +61,8 @@ variable "install_crds" {
 
 variable "domains" {
   description = "map of domains to domain ids and resource groups which certificates will be generated for"
-  #type        = map(string)
   type        = map(object({id = string, resource_group = string}))
+  default     = {}
 }
 
 variable "additional_yaml_config" {


### PR DESCRIPTION
- Allow for specifying resource group of domain inputs (change in variable type)
- Allow for empty list of domains (will be helpful if certmgr is installed by default by flux)
- Change scope of roles to subscription (https://github.com/terraform-providers/terraform-provider-azurerm/issues/7549)
