### PR TITLE
output ips rather that ids

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -3,6 +3,12 @@ data "azuread_service_principal" "aks" {
   application_id = var.service_principal_id
 }
 
+data "azurerm_public_ip" "effective_outbound_ips" {
+  for_each            = azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips
+  name                = split("/", each.value)[(length(split("/", each.value))-1)]
+  resource_group_name = azurerm_kubernetes_cluster.aks.node_resource_group
+}
+
 locals {
   validate_windows_profile_admin_password = (var.enable_windows_node_pools ? (var.windows_profile_admin_password == "" ? file("ERROR: windows_profile_admin_password cannot be empty") : null) : null)
 }

--- a/output.tf
+++ b/output.tf
@@ -18,9 +18,12 @@ output "node_resource_group" {
   value        = azurerm_kubernetes_cluster.aks.node_resource_group
 }
 
-output "effective_outbound_ips_ids" {
+output "effective_outbound_ips" {
   description = "The outcome (resource IDs) of the specified arguments."
-  value       = azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips
+  value       = [
+    for ip in data.azurerm_public_ip.effective_outbound_ips:
+    ip.ip_address
+  ]
 }
   
 output "kube_config_raw" {


### PR DESCRIPTION
This will remove the output of effective_outbound_ips_ids and replace it with effective_outbound_ips.  The output will be a list of IP addresses as opposed to their ids, which should be far more useful.