### PR TITLE
Fixes a bug when using a system-assigned identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,9 +82,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     for_each = (var.identity_type == "ServicePrincipal" ? [] : [1])
     content {
       type                      = var.identity_type
-      user_assigned_identity_id = (var.user_assigned_identity != null ? 
-                                   var.user_assigned_identity.id : 
-                                   azurerm_user_assigned_identity.aks.0.id)
+      user_assigned_identity_id = (var.identity_type == "SystemAssigned" ? null : 
+                                   (var.user_assigned_identity != null ? 
+                                    var.user_assigned_identity.id : 
+                                    azurerm_user_assigned_identity.aks.0.id))
     }
   }
 


### PR DESCRIPTION
When setting `identity_type = "SystemAssigned"`, Terraform would return this error:

```
Error: Invalid index

  on .terraform/modules/aks/main.tf line 87, in resource "azurerm_kubernetes_cluster" "aks":
  87:                                    azurerm_user_assigned_identity.aks.0.id)
    |----------------
    | azurerm_user_assigned_identity.aks is empty tuple

The given key does not identify an element in this collection value.
```

This fixes that.