### PR TITLE
Refactor: update syntax of provider requirements

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    azurerm = ">= 2.0.0"
-    http    = ">= 1.2.0"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.0.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 1.2.0"
+    }
   }
 }


### PR DESCRIPTION
TF 0.13 introduced this new syntax where each provider is declared as a
map with a source and version (contrasting with how things were before,
where you just set the version you wanted). We should always use the new
syntax for explicitness and because the pre-0.13 syntax may be
deprecated some day.