### PR TITLE
Manage the cluster's outbound IP ourselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This module will create a managed Kubernetes cluster using Azure Kubernetes Serv
 | kubelet\_identity | kubelet identity information |
 | name | kubernetes managed cluster name |
 | node\_resource\_group | auto-generated resource group which contains the resources for this managed kubernetes cluster |
+| outbound\_cluster\_ip | The public outbound IP address of the AKS cluster |
 | password | kubernetes password |
 | principal\_id | id of the principal used by this managed kubernetes cluster |
 | username | kubernetes username |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This module will create a managed Kubernetes cluster using Azure Kubernetes Serv
 | client\_certificate | kubernetes client certificate |
 | client\_key | kubernetes client key |
 | cluster\_ca\_certificate | kubernetes cluster ca certificate |
+| cluster\_outbound\_ip | The public outbound IP address of the AKS cluster |
 | effective\_outbound\_ips\_ids | The outcome (resource IDs) of the specified arguments. |
 | fqdn | kubernetes managed cluster fqdn |
 | host | kubernetes host |
@@ -62,7 +63,6 @@ This module will create a managed Kubernetes cluster using Azure Kubernetes Serv
 | kubelet\_identity | kubelet identity information |
 | name | kubernetes managed cluster name |
 | node\_resource\_group | auto-generated resource group which contains the resources for this managed kubernetes cluster |
-| outbound\_cluster\_ip | The public outbound IP address of the AKS cluster |
 | password | kubernetes password |
 | principal\_id | id of the principal used by this managed kubernetes cluster |
 | username | kubernetes username |

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ module "subnet_config" {
   nsg_rule_priority_start = var.subnet_nsg_rule_priority_start
 }
 
-resource "azurerm_public_ip" "outbound_cluster_ip" {
+resource "azurerm_public_ip" "cluster_outbound_ip" {
   name                = "${local.cluster_name}-publicip"
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -60,7 +60,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     load_balancer_sku  = "Standard"
 
     load_balancer_profile {
-      outbound_ip_address_ids = [azurerm_public_ip.outbound_cluster_ip.id]
+      outbound_ip_address_ids = [azurerm_public_ip.cluster_outbound_ip.id]
     }
   }
 

--- a/output.tf
+++ b/output.tf
@@ -23,9 +23,9 @@ output "effective_outbound_ips_ids" {
   value       = azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips
 }
 
-output "outbound_cluster_ip" {
+output "cluster_outbound_ip" {
   description = "The public outbound IP address of the AKS cluster"
-  value       = azurerm_public_ip.outbound_cluster_ip.ip_address
+  value       = azurerm_public_ip.cluster_outbound_ip.ip_address
 }
   
 output "kube_config" {

--- a/output.tf
+++ b/output.tf
@@ -22,6 +22,11 @@ output "effective_outbound_ips_ids" {
   description = "The outcome (resource IDs) of the specified arguments."
   value       = azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips
 }
+
+output "outbound_cluster_ip" {
+  description = "The public outbound IP address of the AKS cluster"
+  value       = azurerm_public_ip.outbound_cluster_ip.ip_address
+}
   
 output "kube_config" {
   description = "kubernetes config to be used by kubectl and other compatible tools"


### PR DESCRIPTION
By default, when not setting a public IP when creating an AKS cluster,
one is created automatically. Instead of doing that, we'll now create
the public IP ourselves and tell AKS to use it. Currently we'll only
support a single IP address as it's easier. This also allows us to
export that IP address in the module's outputs, which is useful when a
cluster will need to connect to another endpoint that has an allowlist.
This makes it easier to manage that allowlist via code.