### PR TITLE
Revert "Manage the cluster's outbound IP ourselves"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ This module will create a managed Kubernetes cluster using Azure Kubernetes Serv
 | client\_certificate | kubernetes client certificate |
 | client\_key | kubernetes client key |
 | cluster\_ca\_certificate | kubernetes cluster ca certificate |
-| cluster\_outbound\_ip | The public outbound IP address of the AKS cluster |
 | effective\_outbound\_ips\_ids | The outcome (resource IDs) of the specified arguments. |
 | fqdn | kubernetes managed cluster fqdn |
 | host | kubernetes host |

--- a/main.tf
+++ b/main.tf
@@ -28,15 +28,6 @@ module "subnet_config" {
   nsg_rule_priority_start = var.subnet_nsg_rule_priority_start
 }
 
-resource "azurerm_public_ip" "cluster_outbound_ip" {
-  name                = "${local.cluster_name}-publicip"
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  tags                = var.tags
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
 resource "azurerm_kubernetes_cluster" "aks" {
   depends_on          = [azurerm_role_assignment.route_table_network_contributor]
 
@@ -57,11 +48,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
     service_cidr       = (var.network_profile_options == null ? null : var.network_profile_options.service_cidr)
     outbound_type      = var.outbound_type
     pod_cidr           = (var.network_plugin == "kubenet" ? var.pod_cidr : null)
-    load_balancer_sku  = "Standard"
-
-    load_balancer_profile {
-      outbound_ip_address_ids = [azurerm_public_ip.cluster_outbound_ip.id]
-    }
   }
 
   default_node_pool {

--- a/output.tf
+++ b/output.tf
@@ -22,11 +22,6 @@ output "effective_outbound_ips_ids" {
   description = "The outcome (resource IDs) of the specified arguments."
   value       = azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips
 }
-
-output "cluster_outbound_ip" {
-  description = "The public outbound IP address of the AKS cluster"
-  value       = azurerm_public_ip.cluster_outbound_ip.ip_address
-}
   
 output "kube_config" {
   description = "kubernetes config to be used by kubectl and other compatible tools"


### PR DESCRIPTION
It was found v3.3.0 (released after #63) breaks things. That PR declared an explicit public IP resource and placed it inside the main resource group containing the AKS cluster, instead of the secondary resource group controlled by the AKS cluster itself. Our user-assigned identity  only has permissions within the scope of the latter resource group and is unable to perform actions against the public IP resource, because it lives outside of that resource group. 

It would be too complicated at this time to fix this for every use case so we're reverting that change. As a result, the v3.3.0 tag will also be deleted.