### PR TITLE
Adding azure policy addon

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     kube_dashboard {
       enabled = var.enable_kube_dashboard
     }
+    
+    azure_policy {
+      enabled = var.enable_azure_policy
+    }
 
     dynamic "oms_agent" {
       for_each = (var.log_analytics_workspace_id != null ? [1] : [])

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
       }
     }
   }
+  timeouts {
+    create = "12h"
+    delete = "12h"
+    update = "12h"
+  }
 }
 
 resource "azurerm_role_assignment" "rbac_admin" {
@@ -157,6 +162,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
 
   upgrade_settings {
     max_surge = each.value.max_surge
+  }
+  timeouts {
+    create = "12h"
+    delete = "12h"
+    update = "12h"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -115,11 +115,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
       }
     }
   }
-  timeouts {
-    create = "12h"
-    delete = "12h"
-    update = "12h"
-  }
 }
 
 resource "azurerm_role_assignment" "rbac_admin" {
@@ -162,11 +157,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
 
   upgrade_settings {
     max_surge = each.value.max_surge
-  }
-  timeouts {
-    create = "12h"
-    delete = "12h"
-    update = "12h"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -271,6 +271,12 @@ variable "enable_kube_dashboard" {
   default     = false
 }
 
+variable "enable_azure_policy" {
+  description = "to apply at-scale enforcements and safeguards on your clusters in a centralized, consistent manner"
+  type        = bool
+  default     = false
+}
+
 variable "acr_pull_access" {
   description = "map of ACR ids to allow AcrPull"
   type        = map(string)


### PR DESCRIPTION
@dutsmiller 
To improve the security of your Azure Kubernetes Service (AKS) cluster, you can apply and enforce built-in security policies on your cluster using Azure Policy.

//for more info
https://docs.microsoft.com/en-us/azure/aks/use-azure-policy?toc=/azure/governance/policy/toc.json&bc=/azure/governance/policy/breadcrumb/toc.json

//also resolves a security alert
![azure_policy_aks_cluster](https://user-images.githubusercontent.com/41235618/126173364-76ae2dcc-4854-4a95-98b3-213fe7ec1a79.PNG)
