### PR TITLE
Add sensitive attribute to kube_config_raw output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -33,6 +33,7 @@ output "kube_config_raw" {
   description = "raw kubernetes config to be used by kubectl and other compatible tools"
   value = (var.rbac.ad_integration ?
   azurerm_kubernetes_cluster.aks.kube_admin_config_raw : azurerm_kubernetes_cluster.aks.kube_config_raw)
+  sensitive = true
 }
 
 output "host" {


### PR DESCRIPTION
Sensitive data cannot be outputted unless the sensitive attribute is set to true.